### PR TITLE
Clean up, early returns & enums

### DIFF
--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -1,9 +1,11 @@
-import { Interaction } from "discord.js"; // Make sure to import necessary types
-import type { Guild, Channel } from "discord.js"; // Import specific types as needed
+import type { Channel, Guild, Interaction } from 'discord.js';
+
+// Make sure to import necessary types
 declare global {
   interface Command {
     name: string;
     handler: any;
+    handler: unknown;
     permissions?: string[];
     description: string;
     options?: object[];
@@ -11,13 +13,12 @@ declare global {
   // src/types/CommandCallback.ts
 
   interface CommandCallback {
-    (
+    type CommandCallback = (
       interaction: Interaction,
       guild: Guild | null,
       channel: Channel | null,
-      config: any
-    ): Promise<void>;
-  }
+      config: Record<string, unknown>
+    ) => Promise<void>;
 }
 
-export { Command, CommandCallback };
+export type { Command, CommandCallback };

--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -4,7 +4,6 @@ import type { Channel, Guild, Interaction } from 'discord.js';
 declare global {
   interface Command {
     name: string;
-    handler: any;
     handler: unknown;
     permissions?: string[];
     description: string;
@@ -12,13 +11,12 @@ declare global {
   }
   // src/types/CommandCallback.ts
 
-  interface CommandCallback {
-    type CommandCallback = (
-      interaction: Interaction,
-      guild: Guild | null,
-      channel: Channel | null,
-      config: Record<string, unknown>
-    ) => Promise<void>;
+  type CommandCallback = (ctx: {
+    interaction: Interaction;
+    guild: Guild | null;
+    channel: Channel | null;
+    config: Record<string, unknown>;
+  }) => Promise<void>;
 }
 
 export type { Command, CommandCallback };

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,5 +1,6 @@
 import {
   ActionRowBuilder,
+  ApplicationCommandOptionType,
   ButtonBuilder,
   ButtonStyle,
   type ChatInputCommandInteraction,
@@ -52,7 +53,7 @@ export default {
     {
       name: 'type',
       description: 'What type of config to edit',
-      type: 3,
+      type: ApplicationCommandOptionType.String,
       required: true,
       choices: [
         {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,11 +1,9 @@
 import {
-  EmbedBuilder,
   ActionRowBuilder,
   ButtonBuilder,
   ButtonStyle,
-  CommandInteraction,
-  Interaction,
-  ChatInputCommandInteraction,
+  type ChatInputCommandInteraction,
+  EmbedBuilder
 } from 'discord.js';
 
 interface Feature {
@@ -16,13 +14,13 @@ interface Feature {
   currentState: 'Enabled' | 'Disabled';
 }
 
-const features: Feature[] = [
+const features = [
   {
     name: 'Prune channel',
     machineName: 'nuke',
     description: 'Clears every message in a channel.',
     permissions: 'ManageChannels',
-    currentState: 'Enabled',
+    currentState: 'Enabled'
   },
   {
     name: 'Archive channel',
@@ -30,9 +28,9 @@ const features: Feature[] = [
     description:
       'Archives a channel sssssssssssssssssssssssssssssssto free up space.',
     permissions: 'ManageChannels',
-    currentState: 'Disabled',
-  },
-];
+    currentState: 'Disabled'
+  }
+] satisfies Feature[];
 
 function createPaddedLabel(
   label: string,
@@ -59,10 +57,10 @@ export default {
       choices: [
         {
           name: 'Features',
-          value: 'features',
-        },
-      ],
-    },
+          value: 'features'
+        }
+      ]
+    }
   ],
   permissions: ['ManageGuild'],
   callback: async (interaction: ChatInputCommandInteraction) => {
@@ -70,7 +68,7 @@ export default {
     if (type !== 'features') {
       return interaction.reply({
         content: 'Feature not implemented yet.',
-        ephemeral: true,
+        ephemeral: true
       });
     }
 
@@ -88,7 +86,7 @@ export default {
         .setFooter({
           text: `Page ${page + 1} of ${Math.ceil(
             features.length / itemsPerPage
-          )}`,
+          )}`
         });
 
       currentFeatures.forEach((feature) => {
@@ -100,7 +98,7 @@ export default {
            ○ **Permissions:** ${feature.permissions}
            ○ **Current State:** ${feature.currentState}
                     `,
-          inline: false,
+          inline: false
         });
       });
 
@@ -159,18 +157,18 @@ export default {
       embeds: [generateEmbed(currentPage)],
       components: [buttonRow1, buttonRow2],
       fetchReply: true,
-      ephemeral: true,
+      ephemeral: true
     });
 
     const collector = embedMessage.createMessageComponentCollector({
-      filter: (i: any) => i.user.id === interaction.user.id,
-      time: 1000 * 60 * 5, // 5-minute timeout
+      filter: (i) => i.user.id === interaction.user.id,
+      time: 1_000 * 60 * 5 // 5-minute timeout
     });
 
-    collector.on('collect', async (btnInteraction: any) => {
+    collector.on('collect', async (btnInteraction) => {
       if (
         btnInteraction.customId === 'next' &&
-        currentPage < Math.ceil(features.length / itemsPerPage) - 1
+                currentPage < Math.ceil(features.length / itemsPerPage) - 1
       ) {
         currentPage++;
       } else if (btnInteraction.customId === 'previous' && currentPage > 0) {
@@ -199,7 +197,7 @@ export default {
       if (!btnInteraction.customId.startsWith('config:')) {
         await btnInteraction.update({
           embeds: [generateEmbed(currentPage)],
-          components: [buttonRow1, buttonRow2],
+          components: [buttonRow1, buttonRow2]
         });
       }
     });
@@ -209,5 +207,5 @@ export default {
       buttonRow2.components.forEach((button) => button.setDisabled(true));
       await embedMessage.delete();
     });
-  },
+  }
 };

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -1,22 +1,20 @@
 import { startupTime } from '@/types/../source';
-import { ChatInputCommandInteraction, Guild, TextChannel } from 'discord.js';
+import type { ChatInputCommandInteraction } from 'discord.js';
+
 export default {
   options: [
     {
       name: 'user',
       description: 'The user to ping',
       type: 3,
-      required: false,
-    },
+      required: false
+    }
   ],
   permissions: ['SendMessages'],
 
   callback: async (
-    interaction: ChatInputCommandInteraction,
-    guild: Guild,
-    channel: TextChannel,
-    config: any
+    interaction: ChatInputCommandInteraction
   ) => {
     return interaction.reply({ content: startupTime, ephemeral: true });
-  },
+  }
 };

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -1,12 +1,12 @@
 import { startupTime } from '@/types/../source';
-import type { ChatInputCommandInteraction } from 'discord.js';
+import { ApplicationCommandOptionType, type ChatInputCommandInteraction } from 'discord.js';
 
 export default {
   options: [
     {
       name: 'user',
       description: 'The user to ping',
-      type: 3,
+      type: ApplicationCommandOptionType.String,
       required: false
     }
   ],

--- a/src/commands/prune-channel.ts
+++ b/src/commands/prune-channel.ts
@@ -1,110 +1,109 @@
 import {
   ActionRowBuilder,
-  EmbedBuilder,
   ButtonBuilder,
+  type ButtonInteraction,
   ButtonStyle,
-  ChatInputCommandInteraction,
-  Guild,
-  TextChannel,
-  ButtonInteraction,
+  type ChatInputCommandInteraction,
+  EmbedBuilder,
+  TextChannel
 } from 'discord.js';
 
 export default {
   permissions: ['ManageChannels'],
-  callback: async (
+  callback: (
     interaction: ChatInputCommandInteraction,
     channel: TextChannel
   ) => {
     const isEnabledInGuild = true;
-    if (isEnabledInGuild) {
-      const channelPosition = channel.position;
-      console.log(channelPosition);
-      if (isNaN(channelPosition))
-        throw new Error(
-          'This channel does not have a position in the category!'
-        );
-      const pruneEmbed = new EmbedBuilder()
-        .setColor('Blurple') // Blurple color
-        .setTitle('Warning: Pruning Channel')
-        .setDescription(
-          'Pruning this channel will result in **deletion of the existing channel** and creation of a **duplicate channel**. This process will:'
-        )
-        .addFields({
-          name: 'Effects:',
-          value:
-            '• **Delete all webhooks** associated with the current channel\n• **Change the Channel ID**, affecting any references to the original ID\n-# We are not liable for any actions that may or may not happen by using this command!',
-        })
-        .setFooter({
-          text: 'Consider these changes before proceeding with channel pruning.',
-        });
+    if (!isEnabledInGuild) throw new Error('This command is disabled in this guild.');
 
-      const buttonRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
-        new ButtonBuilder()
-          .setStyle(ButtonStyle.Success)
-          .setLabel('Cancel')
-          .setCustomId('cancel_prune'),
-        new ButtonBuilder()
-          .setStyle(ButtonStyle.Danger)
-          .setLabel('Confirm')
-          .setCustomId('confirm_prune')
+    const channelPosition = channel.position;
+    console.log(channelPosition);
+    if (isNaN(channelPosition))
+      throw new Error(
+        'This channel does not have a position in the category!'
       );
-
-      interaction.reply({
-        embeds: [pruneEmbed],
-        components: [buttonRow],
-        ephemeral: true,
+    const pruneEmbed = new EmbedBuilder()
+      .setColor('Blurple') // Blurple color
+      .setTitle('Warning: Pruning Channel')
+      .setDescription(
+        'Pruning this channel will result in **deletion of the existing channel** and creation of a **duplicate channel**. This process will:'
+      )
+      .addFields({
+        name: 'Effects:',
+        value:
+            '• **Delete all webhooks** associated with the current channel\n• **Change the Channel ID**, affecting any references to the original ID\n-# We are not liable for any actions that may or may not happen by using this command!'
+      })
+      .setFooter({
+        text: 'Consider these changes before proceeding with channel pruning.'
       });
 
-      const collector = (
-        interaction.channel as TextChannel
-      )?.createMessageComponentCollector({
-        filter: (i) => i.isButton() && i.user.id === interaction.user.id,
-        time: 15000,
-      });
+    const buttonRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setStyle(ButtonStyle.Success)
+        .setLabel('Cancel')
+        .setCustomId('cancel_prune'),
+      new ButtonBuilder()
+        .setStyle(ButtonStyle.Danger)
+        .setLabel('Confirm')
+        .setCustomId('confirm_prune')
+    );
 
-      if (!collector) throw new Error('Collector could not be created.');
+    interaction.reply({
+      embeds: [pruneEmbed],
+      components: [buttonRow],
+      ephemeral: true
+    });
 
-      collector.on('collect', async (i: ButtonInteraction<'cached'>) => {
-        if (i.customId === 'cancel_prune') {
-          await i.update({
-            content: 'Canceled!',
-            embeds: [],
-            components: [],
-          });
-          collector.stop();
-        } else if (i.customId === 'confirm_prune') {
-          const channelPrunedEmbed = new EmbedBuilder()
-            .setColor('DarkButNotBlack')
-            .setDescription('Channel has been successfully nuked!')
-            .setImage('https://c.tenor.com/oikhN7oqj3kAAAAC/tenor.gif')
-            .addFields(
-              {
-                name: 'Add ChannelManager to Your Server | ',
-                value:
+    const collector = (
+      interaction.channel as TextChannel
+    )?.createMessageComponentCollector({
+      filter: (i) => i.isButton() && i.user.id === interaction.user.id,
+      time: 15_000
+    });
+
+    if (!collector) throw new Error('Collector could not be created.');
+
+    collector.on('collect', async (i: ButtonInteraction<'cached'>) => {
+      if (i.customId === 'cancel_prune') {
+        await i.update({
+          content: 'Canceled!',
+          embeds: [],
+          components: []
+        });
+        collector.stop();
+      } else if (i.customId === 'confirm_prune') {
+        const channelPrunedEmbed = new EmbedBuilder()
+          .setColor('DarkButNotBlack')
+          .setDescription('Channel has been successfully nuked!')
+          .setImage('https://c.tenor.com/oikhN7oqj3kAAAAC/tenor.gif')
+          .addFields(
+            {
+              name: 'Add ChannelManager to Your Server | ',
+              value:
                   '[Click here to add ChannelManager](https://top.gg/bot/1211346964554186842) | ',
-                inline: true,
-              },
-              {
-                name: 'Vote for ChannelManager',
-                value:
+              inline: true
+            },
+            {
+              name: 'Vote for ChannelManager',
+              value:
                   '[Click here to vote](https://top.gg/bot/1211346964554186842/vote)',
-                inline: true,
-              }
-            )
-            .setFooter({ text: 'ChannelManager' })
-            .setTimestamp(new Date());
-          if (i.channel instanceof TextChannel) {
-            const newChannel = await i.channel.clone();
-            await newChannel.setPosition(i.channel.position);
-            await newChannel.send({
-              embeds: [channelPrunedEmbed],
-            });
-            await i.channel.delete();
-          } else {
-            throw new Error('This command only works in text channels.');
-          }
-        }
-      });
-    } else throw new Error('This command is disabled in this guild.');
-  },
+              inline: true
+            }
+          )
+          .setFooter({ text: 'ChannelManager' })
+          .setTimestamp(new Date());
+
+        if (!(i.channel instanceof TextChannel)) throw new Error('This command only works in text channels.');
+
+        const newChannel = await i.channel.clone();
+        await newChannel.setPosition(i.channel.position);
+        await newChannel.send({
+          embeds: [channelPrunedEmbed]
+        });
+        await i.channel.delete();
+
+      }
+    });
+  }
 };

--- a/src/commands/purge.ts
+++ b/src/commands/purge.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction, Message, TextChannel } from 'discord.js';
+import type { ChatInputCommandInteraction, TextChannel } from 'discord.js';
 
 export default {
   options: [
@@ -6,8 +6,8 @@ export default {
       name: 'amount',
       description: 'The amount of messages to delete',
       type: 10,
-      required: true,
-    },
+      required: true
+    }
   ],
   permissions: ['ManageMessages'],
   callback: async (
@@ -17,31 +17,31 @@ export default {
     const clearAmount = interaction.options.getNumber('amount');
     if (!clearAmount) throw new Error('You must specify an amount');
     if (clearAmount > 500)
-      throw new Error("You can't delete more than 500 messages");
+      throw new Error('You can\'t delete more than 500 messages');
 
     if (clearAmount <= 0)
-      throw new Error("You can't delete less than 1 message");
-
-    function splitNumber(num: number, chunkSize: number): number[] {
-      const chunks = [];
-      while (num > 0) {
-        const part = Math.min(chunkSize, num);
-        chunks.push(part);
-        num -= part;
-      }
-      return chunks;
-    }
+      throw new Error('You can\'t delete less than 1 message');
 
     const splitChunks = splitNumber(clearAmount, 100);
     for await (const chunk of splitChunks) {
       await channel.bulkDelete(chunk);
     }
     const purgedMessage = await interaction.reply({
-      content: `Deleted ${clearAmount} messages`,
+      content: `Deleted ${clearAmount} messages`
     });
 
     setTimeout(() => {
       purgedMessage.delete();
-    }, 5000);
-  },
+    }, 5_000);
+  }
 };
+
+function splitNumber(num: number, chunkSize: number): number[] {
+  const chunks = [];
+  while (num > 0) {
+    const part = Math.min(chunkSize, num);
+    chunks.push(part);
+    num -= part;
+  }
+  return chunks;
+}

--- a/src/commands/purge.ts
+++ b/src/commands/purge.ts
@@ -1,11 +1,11 @@
-import type { ChatInputCommandInteraction, TextChannel } from 'discord.js';
+import { ApplicationCommandOptionType, type ChatInputCommandInteraction, type TextChannel } from 'discord.js';
 
 export default {
   options: [
     {
       name: 'amount',
       description: 'The amount of messages to delete',
-      type: 10,
+      type: ApplicationCommandOptionType.Number,
       required: true
     }
   ],

--- a/src/events/interactionCreate/commandExecution.ts
+++ b/src/events/interactionCreate/commandExecution.ts
@@ -1,73 +1,67 @@
-import { commands } from '../ready/clientWake';
-import config from '../../../config.json';
-import {
+import type {
   ChatInputCommandInteraction,
-  Guild,
   GuildMember,
-  PermissionResolvable,
-  PermissionsBitField,
-  TextChannel,
+  PermissionResolvable
 } from 'discord.js';
+
+import config from '../../../config.json';
+import { commands } from '../ready/clientWake';
+
 export default async (interaction: ChatInputCommandInteraction) => {
-  if (interaction.isCommand()) {
-    if (!interaction.guild)
-      return interaction.reply({
-        content: 'This command can only be used in a server.',
-        ephemeral: true,
-      });
-    if (!interaction.member) return;
-    const commandHandler = commands.find(
-      (c: TextChannel) => c.name === interaction.commandName
-    ).handler;
-    if (commandHandler) {
-      const botMember = interaction.guild.members.fetch(
-        interaction.client.user.id
-      );
-      const interactionMember = interaction.guild.members.fetch(
-        interaction.user.id
-      );
-      if (
-        !commandHandler.permissions.every((permission: PermissionResolvable) =>
-          (interaction.member as GuildMember).permissions.has(permission)
-        )
-      ) {
-        return interaction.reply({
-          content: `
+  if (!interaction.isCommand()) return;
+  if (!interaction.guild) {
+    return interaction.reply({
+      content: 'This command can only be used in a server.',
+      ephemeral: true
+    });
+  }
+
+  if (!interaction.member) return;
+  if (!commands) return;
+
+  const commandHandler = commands.find((c) => c.name === interaction.commandName)?.handler;
+  if (!commandHandler) return;
+
+  if (
+    !commandHandler.permissions.every((permission: PermissionResolvable) =>
+      (interaction.member as GuildMember).permissions.has(permission)
+    )
+  ) {
+    return interaction.reply({
+      content: `
 - **Error:** \`You're missing vital permissions to use this command!\` 
 - *Required permissions:* **${commandHandler.permissions.join(', ')}**`,
-          ephemeral: true,
-        });
-      }
-      if (
-        !commandHandler.permissions.every((permission: PermissionResolvable) =>
-          (interaction.member as GuildMember).permissions.has(
-            permission as PermissionResolvable
-          )
-        )
-      ) {
-        return interaction.reply({
-          content: `
+      ephemeral: true
+    });
+  }
+
+  if (
+    !commandHandler.permissions.every((permission: PermissionResolvable) =>
+      (interaction.member as GuildMember).permissions.has(
+        permission as PermissionResolvable
+      )
+    )
+  ) {
+    return interaction.reply({
+      content: `
   - **Error:** \`I'm missing vital permissions to use this command!\` 
   - *Required permissions:* **${commandHandler.permissions.join(', ')}**`,
-          ephemeral: true,
-        });
-      }
-      try {
-        await commandHandler.callback(
-          interaction,
-          interaction.guild,
-          interaction.channel,
-          config
-        );
-      } catch (e: string | any) {
-        await interaction.reply({
-          content: `Oh no.. An error has occurred. Please try again later! \n\n\`${e
-            .toString()
-            .slice(0, 50)}\``,
-          ephemeral: true,
-        });
-        console.error('Error executing command:', e); // Log the full error for debugging
-      }
-    }
+      ephemeral: true
+    });
+  }
+
+  try {
+    await commandHandler.callback(
+      interaction,
+      interaction.guild,
+      interaction.channel,
+      config
+    );
+  } catch (e: unknown) {
+    await interaction.reply({
+      content: `Oh no.. An error has occurred. Please try again later! \n\n\`${`${e}`.slice(0, 50)}\``,
+      ephemeral: true
+    });
+    console.error('Error executing command:', e); // Log the full error for debugging
   }
 };

--- a/src/events/interactionCreate/configButtons.ts
+++ b/src/events/interactionCreate/configButtons.ts
@@ -1,29 +1,28 @@
 import { sql } from '@/utils/connections/postgresDb';
-import { ButtonInteraction } from 'discord.js';
-import { QueryResult } from 'pg';
+import type { ButtonInteraction } from 'discord.js';
+
 export default async (interaction: ButtonInteraction<'cached'>) => {
-  if (interaction.isButton() && interaction.customId.startsWith('config:')) {
-    const configType = interaction.customId.split(':')[2];
+  if (!interaction.isButton() || !interaction.customId.startsWith('config:')) return;
 
-    if (configType === 'feature') {
-      const action = interaction.customId.split(':')[1];
-      const featureName = interaction.customId.split(':')[3];
-      const guildId = interaction.guild.id;
+  const configType = interaction.customId.split(':')[2];
+  if (configType !== 'feature') return;
 
-      const enableValue = action === 'enable';
-      console.log(enableValue, guildId, featureName);
+  const action = interaction.customId.split(':')[1];
+  const featureName = interaction.customId.split(':')[3];
+  const guildId = interaction.guild.id;
 
-      const query = `UPDATE config SET ${featureName} = $1 WHERE guild_id = $2`;
-      const values = [enableValue, guildId];
+  const enableValue = action === 'enable';
+  console.log(enableValue, guildId, featureName);
 
-      sql.query(query, values).then((result: QueryResult) => {
-        interaction.reply({
-          content: `Feature ${featureName} has been ${action}d.`,
-          ephemeral: true,
-          components: [],
-          embeds: [],
-        });
-      });
-    }
-  }
+  const query = `UPDATE config SET ${featureName} = $1 WHERE guild_id = $2`;
+  const values = [enableValue, guildId];
+
+  await sql.query(query, values);
+
+  interaction.reply({
+    content: `Feature ${featureName} has been ${action}d.`,
+    ephemeral: true,
+    components: [],
+    embeds: []
+  });
 };

--- a/src/events/messageCreate/cmPrivate.ts
+++ b/src/events/messageCreate/cmPrivate.ts
@@ -1,20 +1,19 @@
+import * as config from '@config';
 import {
   ActionRowBuilder,
   ButtonBuilder,
-  ButtonInteraction,
+  type ButtonInteraction,
   ButtonStyle,
   EmbedBuilder,
-  Message,
-  MessageComponentInteraction,
-  TextChannel,
+  type Message,
+  TextChannel
 } from 'discord.js';
-import * as config from '@config';
+
 export default async (message: Message) => {
   if (!(message.channel instanceof TextChannel)) return;
   if (!message.guild) return;
 
   const ownerId = config.ownerId;
-  const owner = await message.guild.members.fetch(ownerId);
   const args = message.content.split(' ');
   let prefix;
   if (message.client.user.id !== '1303334967949922396') prefix = '.cm';
@@ -74,25 +73,25 @@ export default async (message: Message) => {
           .setDescription(`\`\`\`js\n${originalCode}\n\`\`\``)
           .addFields({
             name: 'Console Output',
-            value: `\`\`\`js\n${finalConsoleOutput.slice(0, 2000)}\n\`\`\``,
+            value: `\`\`\`js\n${finalConsoleOutput.slice(0, 2_000)}\n\`\`\``
           })
           .setColor('Green');
         botResponse = await message.channel.send({ embeds: [embed] });
         setTimeout(() => {
           message.delete();
         }, 500);
-      } catch (error: Error | any) {
+      } catch (error: unknown) {
         console.log = originalConsoleLog;
         message.react('❌');
 
         const errorEmbed = new EmbedBuilder()
           .setTitle('Eval Failed')
           .setDescription(
-            `\`\`\`js\n${error.toString().slice(0, 2000)}\n\`\`\``
+            `\`\`\`js\n${`${error}`.slice(0, 2_000)}\n\`\`\``
           )
           .setColor('Red');
         botResponse = await message.channel.send({
-          embeds: [errorEmbed],
+          embeds: [errorEmbed]
         });
         setTimeout(() => {
           message.delete();
@@ -111,7 +110,7 @@ export default async (message: Message) => {
 
         const collector = message.createMessageComponentCollector({
           filter: (i) => i.customId.startsWith('DeleteEval-'),
-          time: 60000,
+          time: 60_000
         });
 
         collector.on('collect', async (i: ButtonInteraction<'cached'>) => {

--- a/src/events/ready/clientWake.ts
+++ b/src/events/ready/clientWake.ts
@@ -1,13 +1,14 @@
 import loadCommands from '@/utils/handlers/command';
-import { Client } from 'discord.js';
-import path from 'path';
 import Table from 'cli-table3';
-let commands: any = [];
+import type { Client } from 'discord.js';
+import path from 'path';
+
+let commands: Command[] = [];
 
 const commandsTable = new Table({
   head: ['Command', 'Success'],
   style: { head: ['green'] },
-  colWidths: [15, 15],
+  colWidths: [15, 15]
 });
 
 export default async (client: Client) => {
@@ -15,7 +16,7 @@ export default async (client: Client) => {
     client,
     path.join(__dirname, '../../', 'commands')
   );
-  commands.forEach((command: any) => {
+  commands.forEach((command) => {
     commandsTable.push([command.name, '✅']);
   });
   console.log(commandsTable.toString());

--- a/src/utils/connections/postgresDb.ts
+++ b/src/utils/connections/postgresDb.ts
@@ -1,6 +1,5 @@
 import { Pool } from 'pg';
-import 'dotenv/config';
 
 export const sql: Pool = new Pool({
-  connectionString: process.env.DATABASE_STRING,
+  connectionString: process.env.DATABASE_STRING
 });

--- a/src/utils/handlers/command.ts
+++ b/src/utils/handlers/command.ts
@@ -1,14 +1,15 @@
-import {
+import type {
   ApplicationCommand,
   ApplicationCommandDataResolvable,
   ApplicationCommandOption,
   ApplicationCommandOptionData,
   Client,
-  ClientApplication,
+  ClientApplication
 } from 'discord.js';
 import fs from 'fs';
 import path from 'path';
-import type { Command } from '../../@types/global.js';
+
+import type { Command } from '../../@types/global';
 
 const commands: Command[] = [];
 const applicationCommandsArray: object[] = [];
@@ -41,13 +42,13 @@ export default async (
         name: commandName,
         handler: commandHandler,
         description: commandDescription,
-        options: commandHandler.options || [],
+        options: commandHandler.options || []
       });
 
       applicationCommandsArray.push({
         name: commandName,
         description: commandDescription,
-        options: commandHandler.options || [],
+        options: commandHandler.options || []
       });
 
       const fetchedCommand = fetchedCommands.find(
@@ -77,7 +78,7 @@ export default async (
         const normalizeOptions = (options: ApplicationCommandOption[]) => {
           return (
             options
-              // Filter out only options that have a 'required' property, excluding ApplicationCommandSubGroup
+            // Filter out only options that have a 'required' property, excluding ApplicationCommandSubGroup
               .filter((option): option is ApplicationCommandOptionData => {
                 return (
                   'required' in option && typeof option.required === 'boolean'
@@ -87,7 +88,7 @@ export default async (
                 name: option.name,
                 description: option.description,
                 type: option.type,
-                required: (option as any).required, // TypeScript now knows `required` is valid here
+                required: 'required' in option ? option.required : false
               }))
               .sort((a, b) => a.name.localeCompare(b.name))
           );

--- a/src/utils/handlers/event.ts
+++ b/src/utils/handlers/event.ts
@@ -1,6 +1,6 @@
-import { Client } from "discord.js";
-import path from "path";
-import fs from "fs";
+import type { Client } from 'discord.js';
+import fs from 'fs';
+import path from 'path';
 
 export default async (client: Client, eventDir: string): Promise<string[]> => {
   const eventArray = [];
@@ -9,7 +9,7 @@ export default async (client: Client, eventDir: string): Promise<string[]> => {
     console.log(`Loading event: ${event}`);
     const eventFiles = fs.readdirSync(path.join(eventDir, event));
     for (const file of eventFiles) {
-      if (file.endsWith(".ts") || file.endsWith(".js")) {
+      if (file.endsWith('.ts') || file.endsWith('.js')) {
         const eventHandler = await import(
           `${path.join(eventDir, event)}/${file}`
         );


### PR DESCRIPTION
Some things this PR cleans up (examples):
```ts
// from
const allowed = true;
if (allowed) {
   // a shit ton of code
} else throw Error("You can't use this");

// to
const allowed = true;
if (!allowed) throw Error("You can't use this");

// a shit ton of code
```
```js
//from 
{
    options: 3
}

// to
{
    options: ApplicationCommandOptionType.String
}
```

It also removes a lot of `any` type definitions and unused variables